### PR TITLE
Enable downloading Czech model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ URL: https://github.com/bnosac/nametagger
 License: MPL-2.0
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Depends: R (>= 2.10)
 Imports: Rcpp (>= 0.11.5), utils
 Suggests: udpipe (>= 0.2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nametagger
 Type: Package
 Title: Named Entity Recognition in Texts using 'NameTag'
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
     person('Jan', 'Wijffels', role = c('aut', 'cre', 'cph'), email = 'jwijffels@bnosac.be'), 
     person('BNOSAC', role = 'cph'), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## CHANGES IN nametagger VERSION 0.1.4
+
+- nametagger_download_model now allows to download a model for Czech: czech-cnec-140304
+
 ## CHANGES IN nametagger VERSION 0.1.3
 
 - Add explicit initialization to silence false positive valgrind report in compressor_save.cpp

--- a/R/nametagger.R
+++ b/R/nametagger.R
@@ -517,21 +517,21 @@ nametagger_download_model <- function(language = "english", model_dir = tempdir(
   
   language <- match.arg(language, choices = c("english-conll-140408", "czech-cnec-140304"))
   
-  f <- file.path(tempdir(), paste0(language, ".zip"))
+  f <- file.path(tempdir(), paste(language, ".zip", sep = ""))
   switch (language,
     "english-conll-140408" = {
       download.file(url = english_conll_url, destfile = f, mode = "wb")
-      ner_file_path <- paste0(language, "/", language, ".ner")
+      ner_file_path <- paste(language, "/", language, ".ner", sep = "")
       }, 
     "czech-cnec-140304" = {
       download.file(url = czech_cnec_url, destfile = f, mode = "wb")
-      ner_file_path <- paste0(language, "/czech-cnec2.0-140304.ner")
+      ner_file_path <- paste(language, "/czech-cnec2.0-140304.ner", sep = "")
     }
   )
   
   f <- utils::unzip(f, exdir = tempdir(), files = ner_file_path)
   from <- file.path(tempdir(), ner_file_path)
-  to <- file.path(model_dir, paste0(language, ".ner"))
+  to <- file.path(model_dir, paste(language, ".ner", sep = ""))
   file.copy(from, to = to, overwrite = TRUE)
   nametagger_load_model(to)
 }

--- a/R/nametagger.R
+++ b/R/nametagger.R
@@ -501,7 +501,7 @@ czech_cnec_url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/
 #' @title Download a Nametag model
 #' @description Download a Nametag model. Note that models have licence CC-BY-SA-NC. 
 #' More details at \url{https://ufal.mff.cuni.cz/nametag/1}.
-#' @param language Language models available, 'english' or 'czech'
+#' @param language Language model to download, 'english' (default) or 'czech'
 #' @param model_dir a path where the model will be downloaded to.
 #' @return an object of class nametagger 
 #' @references 
@@ -513,7 +513,7 @@ czech_cnec_url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/
 #' \donttest{
 #' model <- nametagger_download_model("english-conll-140408", model_dir = tempdir())
 #' }
-nametagger_download_model <- function(language, model_dir = tempdir()){
+nametagger_download_model <- function(language = "english", model_dir = tempdir()){
   
   language <- match.arg(language, choices = c("english-conll-140408", "czech-cnec-140304"))
   

--- a/R/nametagger.R
+++ b/R/nametagger.R
@@ -495,28 +495,43 @@ print.nametagger_options <- function(x, ...){
   cat(x, sep = "\n")
 }
 
-
+english_conll_url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11234/1-3118/english-conll-140408.zip?sequence=1&isAllowed=y"
+czech_cnec_url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/czech-cnec-140304.zip?sequence=1&isAllowed=y"
 
 #' @title Download a Nametag model
 #' @description Download a Nametag model. Note that models have licence CC-BY-SA-NC. 
 #' More details at \url{https://ufal.mff.cuni.cz/nametag/1}.
-#' @param language 'english-conll-140408'
+#' @param language Language models available, 'english' or 'czech'
 #' @param model_dir a path where the model will be downloaded to.
 #' @return an object of class nametagger 
-#' @references \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-3118}
+#' @references 
+#'  \url{http://ufal.mff.cuni.cz/nametag/users-manual}
+#'  \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-3118}
+#'  \url{https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/}
 #' @export
 #' @examples 
 #' \donttest{
 #' model <- nametagger_download_model("english-conll-140408", model_dir = tempdir())
 #' }
-nametagger_download_model <- function(language = c("english-conll-140408"), model_dir = tempdir()){
-  language <- match.arg(language)
-  f <- file.path(tempdir(), "english-conll-140408.zip")
-  download.file(url = "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11234/1-3118/english-conll-140408.zip?sequence=1&isAllowed=y",
-                destfile = f, mode = "wb")
-  f <- utils::unzip(f, exdir = tempdir(), files = "english-conll-140408/english-conll-140408.ner")
-  from <- file.path(tempdir(), "english-conll-140408/english-conll-140408.ner")
-  to <- file.path(model_dir, "english-conll-140408.ner")
+nametagger_download_model <- function(language, model_dir = tempdir()){
+  
+  language <- match.arg(language, choices = c("english-conll-140408", "czech-cnec-140304"))
+  
+  f <- file.path(tempdir(), paste0(language, ".zip"))
+  switch (language,
+    "english-conll-140408" = {
+      download.file(url = english_conll_url, destfile = f, mode = "wb")
+      ner_file_path <- paste0(language, "/", language, ".ner")
+      }, 
+    "czech-cnec-140304" = {
+      download.file(url = czech_cnec_url, destfile = f, mode = "wb")
+      ner_file_path <- paste0(language, "/czech-cnec2.0-140304.ner")
+    }
+  )
+  
+  f <- utils::unzip(f, exdir = tempdir(), files = ner_file_path)
+  from <- file.path(tempdir(), ner_file_path)
+  to <- file.path(model_dir, paste0(language, ".ner"))
   file.copy(from, to = to, overwrite = TRUE)
   nametagger_load_model(to)
 }

--- a/R/nametagger.R
+++ b/R/nametagger.R
@@ -495,37 +495,38 @@ print.nametagger_options <- function(x, ...){
   cat(x, sep = "\n")
 }
 
-english_conll_url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11234/1-3118/english-conll-140408.zip?sequence=1&isAllowed=y"
-czech_cnec_url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/czech-cnec-140304.zip?sequence=1&isAllowed=y"
 
 #' @title Download a Nametag model
 #' @description Download a Nametag model. Note that models have licence CC-BY-SA-NC. 
 #' More details at \url{https://ufal.mff.cuni.cz/nametag/1}.
-#' @param language Language model to download, 'english' (default) or 'czech'
+#' @param language Language model to download, 'english-conll-140408' (default) or 'czech-cnec-140304'
 #' @param model_dir a path where the model will be downloaded to.
 #' @return an object of class nametagger 
 #' @references 
 #'  \url{http://ufal.mff.cuni.cz/nametag/users-manual}
 #'  \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-3118}
-#'  \url{https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/}
+#'  \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11858/00-097C-0000-0023-7D42-8}
 #' @export
 #' @examples 
 #' \donttest{
 #' model <- nametagger_download_model("english-conll-140408", model_dir = tempdir())
+#' model <- nametagger_download_model("czech-cnec-140304", model_dir = tempdir())
 #' }
-nametagger_download_model <- function(language = "english", model_dir = tempdir()){
+nametagger_download_model <- function(language = c("english-conll-140408", "czech-cnec-140304"), model_dir = tempdir()){
   
-  language <- match.arg(language, choices = c("english-conll-140408", "czech-cnec-140304"))
+  language <- match.arg(language)
   
   f <- file.path(tempdir(), paste(language, ".zip", sep = ""))
   switch (language,
     "english-conll-140408" = {
-      download.file(url = english_conll_url, destfile = f, mode = "wb")
-      ner_file_path <- paste(language, "/", language, ".ner", sep = "")
+      url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11234/1-3118/english-conll-140408.zip?sequence=1&isAllowed=y"
+      download.file(url = url, destfile = f, mode = "wb")
+      ner_file_path <- "english-conll-140408/english-conll-140408.ner"
       }, 
     "czech-cnec-140304" = {
-      download.file(url = czech_cnec_url, destfile = f, mode = "wb")
-      ner_file_path <- paste(language, "/czech-cnec2.0-140304.ner", sep = "")
+      url <- "https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/czech-cnec-140304.zip?sequence=1&isAllowed=y"
+      download.file(url = url, destfile = f, mode = "wb")
+      ner_file_path <- "czech-cnec-140304/czech-cnec2.0-140304.ner"
     }
   )
   

--- a/man/nametagger.Rd
+++ b/man/nametagger.Rd
@@ -15,8 +15,7 @@ nametagger(
   control = nametagger_options(token = list(window = 2)),
   type = if (inherits(control, "nametagger_options")) control$type else "generic",
   tagger = if (inherits(control, "nametagger_options")) control$tagger else "trivial",
-  file = if (inherits(control, "nametagger_options")) control$file else
-    "nametagger.ner"
+  file = if (inherits(control, "nametagger_options")) control$file else "nametagger.ner"
 )
 }
 \arguments{

--- a/man/nametagger_download_model.Rd
+++ b/man/nametagger_download_model.Rd
@@ -4,13 +4,10 @@
 \alias{nametagger_download_model}
 \title{Download a Nametag model}
 \usage{
-nametagger_download_model(
-  language = c("english-conll-140408"),
-  model_dir = tempdir()
-)
+nametagger_download_model(language, model_dir = tempdir())
 }
 \arguments{
-\item{language}{'english-conll-140408'}
+\item{language}{Language models available, 'english' or 'czech'}
 
 \item{model_dir}{a path where the model will be downloaded to.}
 }
@@ -27,5 +24,7 @@ model <- nametagger_download_model("english-conll-140408", model_dir = tempdir()
 }
 }
 \references{
-\url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-3118}
+\url{http://ufal.mff.cuni.cz/nametag/users-manual}
+ \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-3118}
+ \url{https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/}
 }

--- a/man/nametagger_download_model.Rd
+++ b/man/nametagger_download_model.Rd
@@ -4,10 +4,13 @@
 \alias{nametagger_download_model}
 \title{Download a Nametag model}
 \usage{
-nametagger_download_model(language = "english", model_dir = tempdir())
+nametagger_download_model(
+  language = c("english-conll-140408", "czech-cnec-140304"),
+  model_dir = tempdir()
+)
 }
 \arguments{
-\item{language}{Language model to download, 'english' (default) or 'czech'}
+\item{language}{Language model to download, 'english-conll-140408' (default) or 'czech-cnec-140304'}
 
 \item{model_dir}{a path where the model will be downloaded to.}
 }
@@ -21,10 +24,11 @@ More details at \url{https://ufal.mff.cuni.cz/nametag/1}.
 \examples{
 \donttest{
 model <- nametagger_download_model("english-conll-140408", model_dir = tempdir())
+model <- nametagger_download_model("czech-cnec-140304", model_dir = tempdir())
 }
 }
 \references{
 \url{http://ufal.mff.cuni.cz/nametag/users-manual}
  \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-3118}
- \url{https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11858/00-097C-0000-0023-7D42-8/}
+ \url{https://lindat.mff.cuni.cz/repository/xmlui/handle/11858/00-097C-0000-0023-7D42-8}
 }

--- a/man/nametagger_download_model.Rd
+++ b/man/nametagger_download_model.Rd
@@ -4,10 +4,10 @@
 \alias{nametagger_download_model}
 \title{Download a Nametag model}
 \usage{
-nametagger_download_model(language, model_dir = tempdir())
+nametagger_download_model(language = "english", model_dir = tempdir())
 }
 \arguments{
-\item{language}{Language models available, 'english' or 'czech'}
+\item{language}{Language model to download, 'english' (default) or 'czech'}
 
 \item{model_dir}{a path where the model will be downloaded to.}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,11 +5,6 @@
 
 using namespace Rcpp;
 
-#ifdef RCPP_USE_GLOBAL_ROSTREAM
-Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
-Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
-#endif
-
 // nametag_info
 Rcpp::List nametag_info(SEXP model);
 RcppExport SEXP _nametagger_nametag_info(SEXP modelSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // nametag_info
 Rcpp::List nametag_info(SEXP model);
 RcppExport SEXP _nametagger_nametag_info(SEXP modelSEXP) {


### PR DESCRIPTION
I modified the `nametagger_download_model` function so that it can download both English and Czech NER models available from ÚFAL.